### PR TITLE
Use git:directory resource to setup the Gutenberg handbook editor

### DIFF
--- a/src/blueprint-web-browser-gutenberg-handbook.json
+++ b/src/blueprint-web-browser-gutenberg-handbook.json
@@ -2,54 +2,29 @@
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"login": true,
 	"landingPage": "/wp-admin/?markdown-file-path=docs/contributors/accessibility-testing.md",
+	"constants": {
+		"STATIC_FILES_ROOT": "/wordpress/wp-content/static-content"
+	},
 	"steps": [
 		{
-			"step": "unzip",
-			"extractToPath": "/tmp",
-			"zipFile": {
-				"resource": "url",
-				"url": "https://github-proxy.com/proxy/?repo=adamziel/playground-content-converters&branch=explore-markdown-editor-setup&directory=src",
-				"caption": "Downloading Markdown editing plugin"
+			"step": "writeFiles",
+			"writeToPath": "/wordpress/wp-content/plugins",
+			"filesTree": {
+				"resource": "git:directory",
+				"url": "https://github.com/adamziel/playground-content-converters.git",
+				"ref": "trunk",
+				"path": "src"
 			}
 		},
 		{
-			"step": "mkdir",
-			"path": "/wordpress/wp-content/static-content"
-		},
-		{
-			"step": "unzip",
-			"extractToPath": "/wordpress/wp-content/static-content",
-			"zipFile": {
-				"resource": "url",
-				"url": "https://github-proxy.com/proxy/?repo=wordpress/gutenberg&directory=docs",
-				"caption": "Downloading Gutenberg handbook (6MB)"
+			"step": "writeFiles",
+			"writeToPath": "/wordpress/wp-content/static-content",
+			"filesTree": {
+				"resource": "git:directory",
+				"url": "https://github.com/wordpress/gutenberg.git",
+				"ref": "trunk",
+				"path": "docs"
 			}
-		},
-		{
-			"step": "defineWpConfigConsts",
-			"consts": {
-				"STATIC_FILES_ROOT": "/wordpress/wp-content/static-content"
-			}
-		},
-		{
-			"step": "mv",
-			"fromPath": "/tmp/src/convert-markdown-to-blocks-in-js",
-			"toPath": "/wordpress/wp-content/plugins/convert-markdown-to-blocks-in-js"
-		},
-		{
-			"step": "mv",
-			"fromPath": "/tmp/src/import-static-files",
-			"toPath": "/wordpress/wp-content/plugins/import-static-files"
-		},
-		{
-			"step": "mv",
-			"fromPath": "/tmp/src/store-markdown-as-post-meta",
-			"toPath": "/wordpress/wp-content/plugins/store-markdown-as-post-meta"
-		},
-		{
-			"step": "mv",
-			"fromPath": "/tmp/src/save-pages-as-static-files",
-			"toPath": "/wordpress/wp-content/plugins/save-pages-as-static-files"
 		},
 		{
 			"step": "activatePlugin",

--- a/src/blueprint-web-browser-gutenberg-handbook.json
+++ b/src/blueprint-web-browser-gutenberg-handbook.json
@@ -43,8 +43,7 @@
 			"pluginPath": "save-pages-as-static-files/index.php"
 		},
 		{
-			"step": "runPHP",
-			"code": "<?php require '/wordpress/wp-load.php'; $GLOBALS['@pdo']->query('DELETE FROM wp_posts WHERE id > 0'); $GLOBALS['@pdo']->query(\"UPDATE SQLITE_SEQUENCE SET SEQ=0 WHERE NAME='wp_posts'\");  $GLOBALS['@pdo']->query('DELETE FROM wp_postmeta WHERE post_id > 1'); $GLOBALS['@pdo']->query(\"UPDATE SQLITE_SEQUENCE SET SEQ=20 WHERE NAME='wp_postmeta'\"); $GLOBALS['@pdo']->query('DELETE FROM wp_comments'); $GLOBALS['@pdo']->query(\"UPDATE SQLITE_SEQUENCE SET SEQ=0 WHERE NAME='wp_comments'\"); $GLOBALS['@pdo']->query('DELETE FROM wp_commentmeta'); $GLOBALS['@pdo']->query(\"UPDATE SQLITE_SEQUENCE SET SEQ=0 WHERE NAME='wp_commentmeta'\"); "
+			"step": "resetData"
 		}
 	]
 }


### PR DESCRIPTION
Replaces the clunky "Zip, unzip, move files" workflow with a direct git clone built on top of https://github.com/WordPress/wordpress-playground/pull/1858. It's so much nicer!